### PR TITLE
Add ability to customize optimal distance

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -137,7 +137,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.2"
   http:
     dependency: transitive
     description:

--- a/lib/src/layout_algorithm/fruchterman_reingold_algorithm.dart
+++ b/lib/src/layout_algorithm/fruchterman_reingold_algorithm.dart
@@ -18,6 +18,7 @@ class FruchtermanReingoldAlgorithm implements GraphLayoutAlgorithm {
     this.showIterations = false,
     this.initialPositionExtractor = defaultInitialPositionExtractor,
     this.temperature,
+    this.optimalDistance,
   });
 
   /// The number of iterations to run the algorithm
@@ -34,6 +35,9 @@ class FruchtermanReingoldAlgorithm implements GraphLayoutAlgorithm {
 
   /// The temperature of the algorithm. If null, it will be calculated by `sqrt(size.width / 2 * size.height / 2) / 30`
   final double? temperature;
+
+  /// Optimal distance between nodes (k)
+  final double? optimalDistance;
 
   @override
   Stream<GraphLayout> layout({
@@ -71,6 +75,7 @@ class FruchtermanReingoldAlgorithm implements GraphLayoutAlgorithm {
     required GraphLayout? existingLayout,
   }) async* {
     var temp = temperature ?? sqrt(size.width / 2 * size.height / 2) / 30;
+    final k = optimalDistance ?? sqrt(size.width * size.height / nodes.length);
 
     final layoutBuilder = GraphLayoutBuilder(
       nodes: nodes,
@@ -100,6 +105,7 @@ class FruchtermanReingoldAlgorithm implements GraphLayoutAlgorithm {
         edges: edges,
         size: size,
         temp: temp,
+        k: k,
       );
       // Lundy & Mees annealing coefficient model
       //temp = temp /(1 +  0.0001*temp);
@@ -127,10 +133,10 @@ class FruchtermanReingoldAlgorithm implements GraphLayoutAlgorithm {
     required Set<EdgeBase> edges,
     required Size size,
     required double temp,
+    required double k, // Optimal distance between nodes (k)
   }) {
     final width = size.width;
     final height = size.height;
-    final k = sqrt(width * height / nodes.length);
     final repulsionDistanceCutoff = k * 3; // Seems to work the best
     final kSquared = k * k;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: force_directed_graphview
 description: A highly customizable library for displaying force-directed graphs in Flutter.
-version: 0.4.1
+version: 0.4.2
 
 homepage: https://github.com/cupofme/force_directed_graphview
 repository: https://github.com/cupofme/force_directed_graphview


### PR DESCRIPTION
This change adds ability to manually set the optimal edge distance (_k_) for Fruchterman-Reingold algorithms. It is useful in cases when you add a lot of nodes dynamically, and the viewport size is much smaller than the canvas size.